### PR TITLE
PRODENG-2570 Injecting IAM instance profile for nodes

### DIFF
--- a/modules/nodegroup/asg.tf
+++ b/modules/nodegroup/asg.tf
@@ -22,6 +22,9 @@ module "mg" {
   user_data = base64encode(var.user_data)
   key_name  = var.key_pair
 
+  create_iam_instance_profile = false
+  iam_instance_profile_name   = var.instance_profile_name
+
   launch_template_name = var.name
 
   instance_refresh = {

--- a/modules/nodegroup/variables.tf
+++ b/modules/nodegroup/variables.tf
@@ -53,3 +53,7 @@ variable "key_pair" {
   description = "AWS KeyPair name for nodes"
   type        = string
 }
+
+variable "instance_profile_name" {
+  description = "Existing instance profile name to be attached to the nodes"
+}

--- a/nodes.tf
+++ b/nodes.tf
@@ -6,13 +6,14 @@ module "nodegroups" {
 
   name = "${var.name}-${each.key}"
 
-  ami              = each.value.ami
-  type             = each.value.type
-  node_count       = each.value.count
-  root_device_name = each.value.root_device_name
-  volume_size      = each.value.volume_size
-  user_data        = each.value.user_data
-  key_pair         = each.value.keypair_id
+  ami                   = each.value.ami
+  type                  = each.value.type
+  node_count            = each.value.count
+  root_device_name      = each.value.root_device_name
+  volume_size           = each.value.volume_size
+  user_data             = each.value.user_data
+  key_pair              = each.value.keypair_id
+  instance_profile_name = each.value.instance_profile_name
 
   subnets         = module.vpc.public_subnets                                                                # TODO: right how we only support public nodes :(
   security_groups = [for k, sg in local.securitygroups_with_sg : sg.id if contains(sg.nodegroups, each.key)] # attach any sgs listed for this nodegroup

--- a/variables.tf
+++ b/variables.tf
@@ -46,15 +46,16 @@ variable "enable_vpn_gateway" {
 variable "nodegroups" {
   description = "A map of machine group definitions"
   type = map(object({
-    ami              = string
-    keypair_id       = string
-    type             = string
-    count            = number
-    root_device_name = string
-    volume_size      = number
-    role             = string
-    public           = bool
-    user_data        = string
+    ami                   = string
+    keypair_id            = string
+    type                  = string
+    count                 = number
+    root_device_name      = string
+    volume_size           = number
+    role                  = string
+    public                = bool
+    user_data             = string
+    instance_profile_name = optional(string)
   }))
   default = {}
 }


### PR DESCRIPTION
Allow attaching an existing AWS IAM instance profile for all the nodes:
- nodegroups now include a string  variable for an existing Instance profile
- the instance profile is passed to the upstream ASG module
- the upstream ASG module is told to never automatically create a custom instance profile (behaviour change)