### PR TITLE
PRODENG-2573 Changes required for running AWS CCM on MKE

### DIFF
--- a/nodes.tf
+++ b/nodes.tf
@@ -21,7 +21,8 @@ module "nodegroups" {
   tags = merge({
     stack = var.name
     },
-    var.tags
+    var.tags,
+    var.kube_tags,
   )
 }
 

--- a/securitygroups.tf
+++ b/securitygroups.tf
@@ -10,8 +10,10 @@ resource "aws_security_group" "sg" {
     stack = var.name
     role  = "sg"
     unit  = each.key
-  }, var.tags)
-
+    },
+    var.tags,
+    each.value.tags,
+  )
 
   dynamic "ingress" {
     for_each = each.value.ingress_ipv4

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,7 @@ variable "securitygroups" {
       cidr_blocks = list(string)
       self        = bool
     })), [])
+    tags = optional(map(string))
   }))
   default = {}
 }
@@ -103,4 +104,9 @@ variable "ingresses" {
     }))
   }))
   default = {}
+}
+
+variable "kube_tags" {
+  description = "Kubernetes specific tags to be applied to created resources"
+  type        = map(string)
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -21,9 +21,10 @@ module "vpc" {
   enable_nat_gateway = var.enable_nat_gateway
   enable_vpn_gateway = var.enable_vpn_gateway
 
-  enable_dns_support      = true
-  enable_dns_hostnames    = true
-  map_public_ip_on_launch = true
+  enable_dns_support                                = true
+  enable_dns_hostnames                              = true
+  map_public_ip_on_launch                           = true
+  public_subnet_private_dns_hostname_type_on_launch = "resource-name"
 
   tags = merge({
     stack = var.name

--- a/vpc.tf
+++ b/vpc.tf
@@ -28,5 +28,8 @@ module "vpc" {
     stack = var.name
     role  = "vpc"
     unit  = "primary"
-  }, var.tags)
+    },
+    var.tags,
+    var.kube_tags,
+  )
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -21,8 +21,9 @@ module "vpc" {
   enable_nat_gateway = var.enable_nat_gateway
   enable_vpn_gateway = var.enable_vpn_gateway
 
-  enable_dns_support   = true
-  enable_dns_hostnames = true
+  enable_dns_support      = true
+  enable_dns_hostnames    = true
+  map_public_ip_on_launch = true
 
   tags = merge({
     stack = var.name


### PR DESCRIPTION
- Kube specific tags are attached to the required resources as it is a pre-requisite for installing MKE on AWS and also for installing AWS cloud controller manager
- A new optional variable is introduced for security groups so that kube tags can be attached to a single security group. This is needed because AWS CCM expects only a single security group with kube tags.
- Enabled the flag map_public_ip_on_launch for the VPC module since public IPs should be attached to the instances created on public subnets.
- Changed the host name format of the nodes created on public subnet because the format of the ip based hostname was not accepted by CCM (https://cloud-provider-aws.sigs.k8s.io/prerequisites/)