### PR TITLE
PRODENG-2736 Fixing user data for both Linux and Windows based OS

### DIFF
--- a/examples/example.tpl
+++ b/examples/example.tpl
@@ -1,0 +1,5 @@
+#cloud-config
+write_files:
+  - path: /tmp/hello.txt
+    content: |
+      ${cloudconfig}

--- a/examples/output.tf
+++ b/examples/output.tf
@@ -15,4 +15,3 @@ output "platforms" {
   value       = local.platforms_with_ami
   sensitive   = true
 }
-

--- a/examples/provision.tf
+++ b/examples/provision.tf
@@ -1,3 +1,9 @@
+
+// example of templatefile usage to generate user_data
+# locals {
+#   user_data = templatefile("${path.module}/example.tpl", { cloudconfig = ["test_var1"] })
+# }
+
 // locals calculated before the provision run
 locals {
   // combine the nodegroup definition with the platform data

--- a/examples/terraform.tfvars.example
+++ b/examples/terraform.tfvars.example
@@ -49,7 +49,10 @@ nodegroups = {
     volume_size = 100
     role        = "manager"
     public      = true
-    user_data   = ""
+    user_data   = <<-EOF
+                    #!/bin/bash
+                    echo "Hello, World!" > /tmp/hello.txt
+                  EOF
   },
   "AWrk_Ubu22" = { // workers for A group
     platform    = "ubuntu_22.04"

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -48,7 +48,7 @@ variable "nodegroups" {
     volume_size = number
     role        = string
     public      = bool
-    user_data   = string
+    user_data   = optional(string)
   }))
 }
 

--- a/modules/nodegroup/asg.tf
+++ b/modules/nodegroup/asg.tf
@@ -1,4 +1,3 @@
-
 module "mg" {
   source = "terraform-aws-modules/autoscaling/aws"
 

--- a/modules/platform/ami.tf
+++ b/modules/platform/ami.tf
@@ -1,8 +1,4 @@
 locals {
-  user_data_windows = templatefile("${path.module}/userdata_windows.tpl", {
-    windows_administrator_password = var.windows_password
-  })
-
   platform = local.lib_platform_definitions[var.platform_key]
 }
 
@@ -25,6 +21,6 @@ locals {
   platform_with_ami = merge(
     local.platform,
     data.aws_ami.ami,
-    { key : var.platform_key, ami : data.aws_ami.ami.id, user_data : data.aws_ami.ami.platform == "windows" ? local.user_data_windows : "" } // THIS DOES NOT WORK
+    { key : var.platform_key, ami : data.aws_ami.ami.id }
   )
 }


### PR DESCRIPTION
Fixed the user data passing for both Linux and Windows OS
Changed the example to include how to pass user_data from a template
With these changes we make the GCP module and its submodule, platforms, agnostic - we let the user pass/manage their user_data instead of us having some predefined ones.

https://mirantis.jira.com/browse/PRODENG-2736