### PR TITLE
[PRODENG-3471] Add ubuntu_22.04_fips platform

### DIFF
--- a/modules/platform/platforms.tf
+++ b/modules/platform/platforms.tf
@@ -610,6 +610,14 @@ locals {
       "ssh_user" : "ubuntu",
       "ssh_port" : 22
     },
+    "ubuntu_22.04_fips" : {
+      "ami_name" : "ubuntu-pro-fips-updates-server/images/hvm-ssd/ubuntu-jammy-22.04-amd64-pro-fips-updates-server-*",
+      "owner" : "099720109477",
+      "interface" : "ens5"
+      "connection" : "ssh",
+      "ssh_user" : "ubuntu",
+      "ssh_port" : 22
+    },
     "windows_2019" : {
       "ami_name" : "Windows_Server-2019-English-Core-Base-*",
       "owner" : "801119661308",


### PR DESCRIPTION
## What
Add `ubuntu_22.04_fips` platform entry to `modules/platform/platforms.tf`.

## Why
Required to support FIPS smoke testing in Mirantis Launchpad ([PRODENG-3471](https://mirantis.jira.com/browse/PRODENG-3471)). A FIPS-enabled manager node is needed for `TestFIPSCluster`. Ubuntu Pro FIPS 22.04 (Jammy) is the only FIPS-certified Ubuntu AMI currently published by Canonical on AWS — Ubuntu 24.04 FIPS has not yet been published.

## How
- Uses the `ubuntu-pro-fips-updates-server` AMI stream (the stable post-certification update channel, preferred over the base `fips` image for ongoing security updates)
- Owner `099720109477` (Canonical), same as all other Ubuntu entries
- AMI name pattern verified against `aws ec2 describe-images` in us-east-1

## Testing
- `terraform validate` passes on `modules/platform`
- AMI existence confirmed: `ubuntu-pro-fips-updates-server/images/hvm-ssd/ubuntu-jammy-22.04-amd64-pro-fips-updates-server-20250128`

## Links
- JIRA: [PRODENG-3471](https://mirantis.jira.com/browse/PRODENG-3471)
- Launchpad PR: [Mirantis/launchpad#640](https://github.com/Mirantis/launchpad/pull/640)

## Checklist
- [ ] Tests added or updated
- [ ] Docs updated if user-visible behaviour changed
- [ ] No debug output or dead code left in

Written by AI: claude-sonnet-4-5